### PR TITLE
Use the buffer npm package for browser compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fission-bloom-filters",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "JS implementation of probabilistic data structures: Bloom Filter (and its derived), HyperLogLog, Count-Min Sketch, Top-K and MinHash",
   "main": "dist/api.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
+    "buffer": "^6.0.3",
     "is-buffer": "^2.0.4",
     "lodash": "^4.17.15",
     "lodash.eq": "^4.0.0",

--- a/src/iblt/cell.ts
+++ b/src/iblt/cell.ts
@@ -24,6 +24,7 @@ SOFTWARE.
 
 'use strict'
 
+import { Buffer } from 'buffer'
 import { hashTwiceAsString, xorBuffer } from '../utils'
 import { AutoExportable, Field, Parameter } from '../exportable'
 import BaseFilter from '../base-filter'

--- a/src/iblt/invertible-bloom-lookup-tables.ts
+++ b/src/iblt/invertible-bloom-lookup-tables.ts
@@ -24,6 +24,7 @@ SOFTWARE.
 
 'use strict'
 
+import { Buffer } from 'buffer'
 import BaseFilter from '../base-filter'
 import WritableFilter from '../interfaces/writable-filter'
 import Cell from './cell'

--- a/src/sketch/hyperloglog.ts
+++ b/src/sketch/hyperloglog.ts
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+import { Buffer } from 'buffer'
 import BaseFilter from '../base-filter'
 import { AutoExportable, Field, Parameter } from '../exportable'
 import { HashableInput, allocateArray, hashAsInt } from '../utils'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,7 @@ SOFTWARE.
 'use strict'
 
 import XXH from 'xxhashjs'
+import { Buffer } from 'buffer'
 
 /**
  * Utilitaries functions

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,6 +102,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -114,6 +119,14 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 camelcase@^5.0.0:
   version "5.3.1"
@@ -373,6 +386,11 @@ highlight.js@^9.17.1:
   version "9.18.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
   integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION
When building `webnative`, we have to inject the `Buffer` class from the `buffer` library when building for node.

With this PR, that won't be necessary anymore. Instead, the bloom-filters library will just use the `buffer` library. In node, it'll just expose the node-native Buffer class.
