### PR TITLE
fix: indices stack overflow

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,28 +173,34 @@ export function doubleHashing (n: number, hashA: number, hashB: number, size: nu
  * @param  seed     - The seed used
  * @return A array of indexes
  * @author Arnaud Grall
+ * @author Simon Woolf (SimonWoolf)
  */
 export function getDistinctIndices (element: HashableInput, size: number, number: number, seed?: number): Array<number> {
   if (seed === undefined) {
     seed = getDefaultSeed()
   }
-  function getDistinctIndicesBis (n: number, elem: HashableInput, size: number, count: number, indexes: Array<number> = []): Array<number> {
-    if (indexes.length === count) {
-      return indexes
-    } else {
-      const hashes = hashTwice(elem, true, seed! + size % n)
-      const ind = doubleHashing(n, hashes.first, hashes.second, size)
-      if (indexes.includes(ind)) {
-        // console.log('generate index: %d for %s', ind, elem)
-        return getDistinctIndicesBis(n + 1, elem, size, count, indexes)
-      } else {
-        // console.log('already found: %d for %s', ind, elem)
-        indexes.push(ind)
-        return getDistinctIndicesBis(n + 1, elem, size, count, indexes)
-      }
+
+  const indexes = new Set<number>()
+  let n = 0
+  let hashes = hashTwice(element, true, seed)
+
+  while (indexes.size < number) {
+    const ind = hashes.first % size
+    if (!indexes.has(ind)) {
+      indexes.add(ind)
+    }
+
+    hashes.first = (hashes.first + hashes.second) % size
+    hashes.second = (hashes.second + n) % size
+    n++
+
+    if (n > size) {
+      seed++
+      hashes = hashTwice(element, true, seed)
     }
   }
-  return getDistinctIndicesBis(1, element, size, number)
+
+  return [...indexes.values()]
 }
 
 /**


### PR DESCRIPTION
The bloom filter's [getDistinctIndexes](https://github.com/Callidon/bloom-filters/blob/master/src/hashing/hashing.ts#L74) with some inputs can cause a stack overflow.

The code reproduces this error:
```javascript
import { BloomFilter } from 'fission-bloom-filters'

const f = new BloomFilter(5, 4)

f.seed = 2000679582

const raw = new Uint8Array([0x01, 0x71, 0x12, 0x20, 0x9c, 0x4e, 0x9b, 0x9f, 0x68, 0x6b, 0xeb, 0xd1, 0xf2, 0x2b, 0x65, 0x1f, 0x0a, 0x72, 0xf8, 0xb3, 0x14, 0xb7, 0xd1, 0x13, 0xb0, 0x58, 0xa6, 0x72, 0xf2, 0x09, 0x42, 0xe0, 0x04, 0x19, 0xcb, 0x80])
const item = raw.buffer.slice(raw.byteOffset, raw.byteLength + raw.byteOffset)

f.add(item)
```

This PR updates the method to match the [upstream implementation](https://github.com/Callidon/bloom-filters/blob/master/src/hashing/hashing.ts#L74).

This PR seems to break a couple of the **Invertible Bloom Lookup Tables** test cases (collisions?):
```
  58 passing
  2 failing

  1) Invertible Bloom Lookup Tables
       Set differences of [10 to 100] with 1000 keys, 3 hash functions, [alpha = 1.5, d = 100]=150 cells
         should decodes correctly element for a set difference of 100:

      AssertionError: expected false to equal true
      + expected - actual

      -false
      +true
      
      at commonTest (test/iblt-test.js:220:26)
      at Context.<anonymous> (test/iblt-test.js:180:9)
      at process.processImmediate (node:internal/timers:476:21)

  2) Invertible Bloom Lookup Tables
       [Performance] Set differences of [10 to 100] with 1000 keys, 3 hash functions, [alpha = 1.5, d = 100]=150 cells
         should decodes correctly element for a set difference of 100:

      AssertionError: expected false to equal true
      + expected - actual

      -false
      +true
      
      at commonTest (test/iblt-test.js:220:26)
      at Context.<anonymous> (test/iblt-test.js:187:9)
      at process.processImmediate (node:internal/timers:476:21)

```